### PR TITLE
Don't pass port in redirects

### DIFF
--- a/scripts/config/templates/nginx.conf.erb
+++ b/scripts/config/templates/nginx.conf.erb
@@ -29,6 +29,7 @@ http {
 
   server {
     listen <%= port %> reuseport;
+    port_in_redirect off;
     keepalive_timeout 5;
     root <%= root %>;
   <% if error_page %>


### PR DESCRIPTION
So that when nginx does redirects (when adding a trailing slash), it doesn't do it with the internal port specified.